### PR TITLE
Fix typo in 'About Laravel' section

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
 </p>
 
-## About Laravel
+## About Larave
 
 Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
 


### PR DESCRIPTION
Corrected a typo in the 'About Laravel' section.